### PR TITLE
Add objcopy and objdump

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,6 +61,13 @@ apps:
   sbsign:
     command: usr/bin/sbsign
     adapter: full
+  # in case patching/inspecting the binaries manually is needed
+  objcopy:
+    command: usr/bin/objcopy
+    adapter: full
+  objdump:
+    command: usr/bin/objdump
+    adapter: full
 
 parts:
   scripts:


### PR DESCRIPTION
The tools are useful when inspecting/modifying kernel.efi and other binaries.